### PR TITLE
Create nginx-ssl.conf

### DIFF
--- a/overlay/usr/local/etc/nginx/nginx-ssl.conf
+++ b/overlay/usr/local/etc/nginx/nginx-ssl.conf
@@ -1,0 +1,66 @@
+worker_processes 1;
+pid /var/run/nginx.pid;
+user www www;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include            mime.types;
+    default_type       application/octet-stream;
+    sendfile           on;
+    keepalive_timeout  65;
+
+    server {
+        server_name tasmoadmin.local;
+        listen 443 default_server ssl;
+        listen [::]:443 default_server ssl;
+        root /usr/local/www/tasmoadmin;
+        index index.php;
+        
+        ssl_certificate /usr/local/www/tasmoadmin/data/tasmoadmin.crt;
+        ssl_certificate_key /usr/local/www/tasmoadmin/data/tasmoadmin.key;
+        ssl_protocols TLSv1.2;
+        ssl_prefer_server_ciphers on;
+        ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES25
+        ssl_ecdh_curve secp384r1;
+        ssl_session_timeout  10m;
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_tickets off;
+        ssl_stapling on;
+        ssl_stapling_verify on;
+
+        location /data/firmwares {
+        }
+
+        location /data/ {
+            deny all;
+        }
+
+        location ~ .php$ {
+            fastcgi_pass unix:/var/run/php-fpm.sock;
+            fastcgi_read_timeout 900;
+            fastcgi_split_path_info ^(.+\.php)(/.+)$;
+            fastcgi_index index.php;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            include fastcgi_params;
+        }
+
+        location ~ ^(.*)\.(css|js|gif||jpe?g|png|json|cache\.json)$ {
+        }
+
+        location / {
+            rewrite ^/login$ /login.php last;
+            rewrite ^/logout$ /login.php?logout=logout last;
+            rewrite ^/doAjaxAll$ /index.php?doAjaxAll=doAjaxAll last;
+            rewrite ^/doAjax$ /index.php?doAjax=doAjax last;
+            rewrite "/([a-z]{2})/" /index.php?lang=$1 last;
+            rewrite ^/([a-zA-Z_]+)/([a-zA-Z_]+)/([0-9_]+)/?$ /index.php?page=$1&action=$2&device_id=$3;
+            rewrite ^/([a-zA-Z_]+)/(force)/?$ /index.php?page=$1&force=1;
+            rewrite ^/([a-zA-Z_]+)/([a-zA-Z_]+)/?$ /index.php?page=$1&action=$2;
+            rewrite ^/([a-zA-Z_]+)/([0-9]+)/?$ /index.php?page=$1&device_id=$2;
+            rewrite ^/([a-zA-Z_]+)/?$ /index.php?page=$1;
+        }
+    }
+}


### PR DESCRIPTION
This configuration should be used for Nginx if SSL is desired. It should replace nginx.conf in /usr/local/etc/nginx/ and named nginx.conf based on current conventions. Ideally post_install.sh would be modified to pass an option to enable SSL which would copy this file instead of the non-SSL version. Nice to haves would be specifying crt and key names. I was unable to get "certificate" and "keyfile" in MyConfig.json to point to the crt and key by a different name.